### PR TITLE
fix: symtab length

### DIFF
--- a/assembler.h
+++ b/assembler.h
@@ -85,12 +85,8 @@ string dec2bin(int value)
 }
 
 /* Opens the file and reads it, creates a table of tokens (no spaces) */
-void openFile()
+void openFile(char *filename)
 {
-    char filename[400];
-
-    cout << "Enter filename (.txt extension is required)" << endl;
-    cin.getline(filename, 400);
     ifstream file;
     file.open(filename);
 
@@ -686,7 +682,7 @@ void printFile() //This function prints to file.
     oFile << "CONTENT BEGIN" << endl;
 
     int lineCounter = 0; //The line counter records the line address count.
-    int numberOfSymbols = symbols.size() -1; //This is the number of symbols we parsed from the assembly file.
+    int numberOfSymbols = symbols.size(); //This is the number of symbols we parsed from the assembly file.
     int symbolCounter = 0; //Whenever we iterate through the symbols vector we want to keep count as to not overflow.
     string instruction; //This string holds the final instruction in HEX for printing.
     int labelsCounter = 0; //We keep a count of the labels we find in the symbols vector.

--- a/main.cpp
+++ b/main.cpp
@@ -9,9 +9,13 @@
 
 using namespace std;
 
-int main()
+int main(int argc, char *argv[])
 {
-    openFile();
+    if(argc < 2) {
+        cout << "Usage: " << argv[0] << " <filename>" << endl;
+        return 1;
+    }
+    openFile(argv[1]);
     cout << "file open and parsed..." << endl;
     compareTokens();
     cout << "Tokens Compared..." << endl;


### PR DESCRIPTION
I found that `numberOfSymbols` is calculated wrong. Removing `-1` fixed that.

Test case:

```mips
sw $0, 0($1)
```

Also, I made a change to how the filename is passed.